### PR TITLE
feat: Add support for question-specific header images and update styl…

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ It includes interactive features such as **answer streaks, animations, and autom
 ## ✨ Features
 
 - 🎯 **Dynamic Quizzes** – Questions with multiple-choice answers.  
-- 🔥 **Streaks** – Encourages focus and motivation by rewarding consecutive correct answers.  
+- �️ **Visual Learning** – Support for both quiz-level and question-specific header images.
+- �🔥 **Streaks** – Encourages focus and motivation by rewarding consecutive correct answers.  
 - 📄 **Cheat Sheets** – Auto-generated review sheets based on user performance.  
 - 🎨 **Polished UI** – Animations and feedback for a more engaging learning experience.  
 - 🌐 **Extensible Back End** – Optional score-tracking API with examples in Node, PHP, and Python.  
@@ -158,6 +159,7 @@ Quizimodo uses a straightforward JSON format for defining quizzes. Each quiz is 
   "title": "Quiz Title",
   "description": "Short description of the quiz content",
   "time": "15 minutes",
+  "headerimage": "/topic/header.png", 
   "questions": [
     {
       "id": 1,
@@ -176,6 +178,34 @@ Quizimodo uses a straightforward JSON format for defining quizzes. Each quiz is 
 ```
 
 ### Advanced Quiz Features
+
+#### Header Images
+
+You can include header images at two levels:
+
+1. **Quiz-level header image**: Displayed at the top of the quiz for all questions:
+
+```json
+{
+  "title": "My Quiz",
+  "description": "Quiz description",
+  "headerimage": "/topic/header.png"
+}
+```
+
+2. **Question-specific header images**: Each question can have its own unique header image that overrides the quiz-level image:
+
+```json
+{
+  "id": 2,
+  "headerimage": "https://example.com/images/specific-question-image.jpg",
+  "question": "What is the question?",
+  "options": ["Option A", "Option B", "Option C", "Option D"],
+  "answer": 1
+}
+```
+
+When a question has its own `headerimage`, the quiz-level header image will not be displayed for that particular question. This allows for targeted visual aids that are specific to individual questions.
 
 #### Code Examples
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -306,8 +306,9 @@ function App({ topic = DEFAULT_TOPIC, initialQuiz }: AppProps) {
       <header>
         {quizState.quizData && !quizState.quizCompleted && (
           <div className="quiz-header">
-            {/* Show quiz theme image if available */}
-            {quizImagePath && (
+            {/* Show quiz theme image if available and the current question doesn't have its own headerimage */}
+            {quizImagePath && 
+             (!quizState.quizData.questions[quizState.currentQuestionIndex]?.headerimage) && (
               <img
                 src={quizImagePath}
                 alt="Quiz Theme"

--- a/src/QuizQuestion.css
+++ b/src/QuizQuestion.css
@@ -10,6 +10,18 @@
   box-sizing: border-box;
 }
 
+.question-image-container {
+  margin-bottom: 20px;
+  text-align: center;
+}
+
+.question-image {
+  max-width: 100%;
+  max-height: 300px;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
 .streak-counter {
   position: absolute;
   top: -15px;

--- a/src/QuizQuestion.tsx
+++ b/src/QuizQuestion.tsx
@@ -86,6 +86,17 @@ const QuizQuestion = ({ question, onAnswer, correctStreak = 0 }: QuizQuestionPro
           {correctStreak >= 3 && <span className="streak-fire">🔥</span>}
         </div>
       )}
+      
+      {question.headerimage && (
+        <div className="question-image-container">
+          <img 
+            src={question.headerimage} 
+            alt="Question illustration" 
+            className="question-image" 
+          />
+        </div>
+      )}
+      
       <h2 dangerouslySetInnerHTML={renderHTML(question.question)} />
       
       {question.example && (

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ export interface Question {
   answer: number; // index of the correct option
   explanation?: string; // Optional explanation to show after answering
   exampleExplanation?: string; // Optional HTML example for the explanation
+  headerimage?: string; // Optional question-specific header image
 }
 
 export interface QuizData {


### PR DESCRIPTION
This pull request adds support for header images at both the quiz and question levels, enhancing the visual learning experience. It updates the documentation to explain these new features, modifies the UI to display the appropriate images, and updates the data model and styling to accommodate question-specific images.

**Feature: Header Images for Visual Learning**
- Added support for quiz-level and question-specific header images, allowing each question to optionally override the main quiz image. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L16-R17) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R162) [[3]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aR9)
- Updated the README with documentation and usage examples for header images at both the quiz and question levels.

**UI/UX Updates**
- Modified the quiz header logic in `App.tsx` to only show the quiz-level image if the current question does not have its own header image.
- Updated `QuizQuestion.tsx` to display a question-specific image when provided.
- Added new CSS styles for displaying question images in `QuizQuestion.css`.